### PR TITLE
feat: Add support for runtime addition of config.ttl + shiro.ini files via environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ARG OTEL_JAR="opentelemetry-javaagent.jar"
 ARG JAVA_MINIMAL="/opt/java-minimal"
 ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec,jdk.httpserver"
 
-
 ###########################################################
 # Build Fuseki from sources and include GeoSPARQL support #
 ###########################################################
@@ -96,7 +95,8 @@ FROM --platform=${TARGETPLATFORM} "docker.io/library/alpine:${ALPINE_VERSION}"
 # install some required dependencies
 RUN apk add --no-cache \
   ca-certificates \
-  gettext
+  gettext \
+  curl
 
 ARG JENA_VERSION
 ARG FUSEKI_HOME
@@ -112,13 +112,13 @@ COPY --from=deps "${FUSEKI_HOME}" "${FUSEKI_HOME}"
 # -u: explicit UID
 RUN adduser -H -D -u 1000 fuseki fuseki
 
-RUN mkdir -p "${FUSEKI_BASE}/databases" \
-  && chown -R fuseki "${FUSEKI_BASE}"
+RUN mkdir -p "${FUSEKI_BASE}/databases"
 
 WORKDIR "${FUSEKI_HOME}"
 COPY config/log4j2.properties config/shiro.ini entrypoint.sh ./
 COPY config/config.ttl "${FUSEKI_BASE}"
-RUN chmod +x entrypoint.sh
+RUN chmod +x entrypoint.sh \
+ && chown -R fuseki "${FUSEKI_BASE}"
 
 # default environment variables
 ENV \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,18 @@
 
 export OTEL_RESOURCE_ATTRIBUTES="container.id=$(hostname),${OTEL_RESOURCE_ATTRIBUTES}"
 
-envsubst '$ADMIN_PASSWORD' \
-  < "${FUSEKI_HOME}/shiro.ini" \
-  > "${FUSEKI_BASE}/shiro.ini"
+if [ -n "${CONFIG_LOCATION}" ]; then
+  curl "${CONFIG_LOCATION}" -s >"$FUSEKI_BASE/config.ttl" &&
+    echo Added config.ttl from "${CONFIG_LOCATION}"
+fi
+if [ -n "${SHIRO_LOCATION}" ]; then
+  curl "${SHIRO_LOCATION}" -s >"$FUSEKI_BASE/shiro.ini" &&
+    echo Added shiro.ini from "${SHIRO_LOCATION}"
+else
+  envsubst '$ADMIN_PASSWORD' \
+    <"${FUSEKI_HOME}/shiro.ini" \
+    >"${FUSEKI_BASE}/shiro.ini"
+fi
 
 exec \
   "${JAVA_HOME}/bin/java" \


### PR DESCRIPTION
This PR adds a feature to allow the retrieval of remote (or local) configuration and security files at runtime. The `CONFIG_LOCATION` and `SHIRO_LOCATION` environment variables can be specified when creating a docker container to retrieve `config.ttl` and/or `shiro.ini` files from remote or local locations via curl.

For example a configuration file could be hosted in an S3 bucket and retrieved at runtime.
For local testing, curl can read from a local filesystem using `file:///<file path>`
Examples:
Remote:
```
docker run 
  -p 3030:3030 
  -e CONFIG_LOCATION=https://my-s3-bucket.s3.ap-southeast-2.amazonaws.com/config.ttl
  fuseki-geosparql
```
Local:
```
docker run 
  -p 3030:3030 
  -v $PWD/config:/custom-config 
  -e CONFIG_LOCATION=file:///custom-config/config.ttl 
  fuseki-geosparql
```
NB I've moved the line `chown -R fuseki "${FUSEKI_BASE}"` so that config.ttl is not owned by root and can be overwritten by the jena user - not sure if there was a reason to have the config.ttl owned by root