### PR TITLE
Be more restrictive with default permissions

### DIFF
--- a/.changeset/perfect-dodos-speak.md
+++ b/.changeset/perfect-dodos-speak.md
@@ -1,0 +1,13 @@
+---
+"fuseki-geosparql": major
+---
+
+Require to be authenticated for endpoints with write access.
+
+Starting this version, all routes that are ending with:
+
+- `/data`
+- `/upload`
+- `/update`
+
+are also protected and require authentication.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ All other routes that have are prefixed with `/$/` needs basic authentication:
 - username: `admin`
 - password: value of the `ADMIN_PASSWORD` environment variable
 
+Some routes that are known to be used for write permissions are also protected; there are the ones ending with:
+
+- `/data`
+- `/upload`
+- `/update`
+
 All other routes are publicly available.
 
 If you want to change this behavior, you will need to change the `config/shiro.ini` file.

--- a/config/shiro.ini
+++ b/config/shiro.ini
@@ -19,6 +19,9 @@ admin = ${ADMIN_PASSWORD}
 
 ## and the rest are restricted to admin user
 /$/** = authcBasic,user[admin]
+/**/data = authcBasic,user[admin]
+/**/upload = authcBasic,user[admin]
+/**/update = authcBasic,user[admin]
 
 # Everything else
 /**=anon


### PR DESCRIPTION
Routes that are known to be used for write operations should be protected by default.