### PR TITLE
Upgrade otel to 1.32.0

### DIFF
--- a/.changeset/sweet-moons-tease.md
+++ b/.changeset/sweet-moons-tease.md
@@ -1,0 +1,5 @@
+---
+"fuseki-geosparql": patch
+---
+
+Upgrade OpenTelemetry Instrumentation for Java to 1.32.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # manage tools versions
 ARG ALPINE_VERSION="3.18.4"
 ARG JENA_VERSION="4.10.0"
-ARG OTEL_VERSION="1.31.0"
+ARG OTEL_VERSION="1.32.0"
 ARG MAVEN_VERSION="3.9.5"
 
 # configure some paths, names and args


### PR DESCRIPTION
This PR upgrades OpenTelemetry Instrumentation for Java to 1.32.0.