### PR TITLE
Disable OTEL using `DISABLE_OTEL=false`

### DIFF
--- a/.changeset/loud-files-live.md
+++ b/.changeset/loud-files-live.md
@@ -1,0 +1,5 @@
+---
+"fuseki-geosparql": minor
+---
+
+OpenTelemetry support can be disabled by configuring the `DISABLE_OTEL` environment variable to `false`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,8 @@ ENV \
   FUSEKI_BASE="${FUSEKI_BASE}" \
   OTEL_TRACES_EXPORTER="none" \
   OTEL_METRICS_EXPORTER="none" \
-  ADMIN_PASSWORD="admin"
+  ADMIN_PASSWORD="admin" \
+  DISABLE_OTEL="false"
 
 # run as "fuseki" (explicit UID so "run as non-root" policies can be enforced)
 USER 1000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,18 @@ envsubst '$ADMIN_PASSWORD' \
   < "${FUSEKI_HOME}/shiro.ini" \
   > "${FUSEKI_BASE}/shiro.ini"
 
+JAVA_AGENT="-javaagent:${FUSEKI_HOME}/otel.jar"
+
+# Check if the environment variable DISABLE_OTEL is set to "true"
+if [ "$DISABLE_OTEL" = "true" ]; then
+  echo "Removing OpenTelemetry Java Agent…"
+  JAVA_AGENT=""
+fi
+
 exec \
   "${JAVA_HOME}/bin/java" \
   ${JAVA_OPTS} \
-  -javaagent:"${FUSEKI_HOME}/otel.jar" \
+  ${JAVA_AGENT} \
   -Xshare:off \
   -Dlog4j.configurationFile="${FUSEKI_HOME}/log4j2.properties" \
   -cp "${FUSEKI_HOME}/fuseki-server.jar" \


### PR DESCRIPTION
OpenTelemetry support can be disabled by configuring the `DISABLE_OTEL` environment variable to `false`.

Closes #26.