### PR TITLE
chmod for all in fuseki base and /opt/derby

### DIFF
--- a/.changeset/jolly-shirts-join.md
+++ b/.changeset/jolly-shirts-join.md
@@ -1,0 +1,5 @@
+---
+"fuseki-geosparql": minor
+---
+
+Improve permissions for the container image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,8 @@ COPY --from=builder /build/*.jar "${FUSEKI_HOME}/"
 RUN adduser -H -D -u 1000 fuseki fuseki
 
 RUN mkdir -p "${FUSEKI_BASE}/databases" "${FUSEKI_BASE}/configuration" /opt/derby \
-  && chown -R fuseki:fuseki "${FUSEKI_HOME}" "${FUSEKI_BASE}" "${FUSEKI_BASE}/configuration" /opt/derby
+  && chown -R fuseki:fuseki "${FUSEKI_HOME}" "${FUSEKI_BASE}" "${FUSEKI_BASE}/configuration" /opt/derby \
+  && chmod -R a+w "${FUSEKI_BASE}" /opt/derby
 
 WORKDIR "${FUSEKI_HOME}"
 COPY config/log4j2.properties config/shiro.ini entrypoint.sh ./


### PR DESCRIPTION
This allows to use the image with any userid, e.g. in a kubernetes cluster with specific uid policies.